### PR TITLE
Simple check if option is known. Should close #18.

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -61,8 +61,7 @@ elif [ ! $(command -v "$_APTMGR") ]; then
 fi
 
 # If the user entered arguments contain upgrade, install, or dist-upgrade
-i=1
-for option in $@; do  # simple test for unknown options
+for option in $@; do  # search for known options
 if [ "$option" == "upgrade" ] ||
     [ "$option" == "install" ] ||
     [ "$option" == "dist-upgrade" ] ||
@@ -126,23 +125,11 @@ if [ "$option" == "upgrade" ] ||
   break
 
 
-elif [ "$option" == "autoclean" ] ||
-    [ "$option" == "autoremove" ] ||
-    [ "$option" == "check" ] ||
-    [ "$option" == "clean" ] ||
-    [ "$option" == "purge" ] ||
-    [ "$option" == "remove" ] ||
-    [ "$option" == "update" ]; then
+else
   "${_APTMGR}" $@
   break
 
-elif [ $i -ge $# ]; then
-  echo -e "${cRed} Unknown option passed.\n${endColor}"
-  LCK_RM
-  exit 1
-
 fi
-i=$(($i + 1))
 done
 
 # Downtime befor remove the lockfile


### PR DESCRIPTION
Perhaps instead of 3 parts known-using-downloadhelper, known-no-need-for-downloadhelper and unknown-abort, we could use 2 parts: known-using-downloadhelper, everything-else-let-package-manager-decide

I prefer 2nd solution with only 2 parts but imho better error handling (this pull request implements atm 1st solution). At the moment not supported commands (apt-get):
- `source`
- `build-dep`
- `download`
- `changelog`

We should find a downloadhelper solution for the first three.

aptitude knows a lot of more commands what is an additional reason for solution 2.
