### PR TITLE
add -x parameter for aria2c to speed up downloading

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -130,7 +130,7 @@ endColor='\e[0m'
 APT_FAST_TIMEOUT=60
 
 # Download command.
-_DOWNLOADER='aria2c -c -j ${_MAXNUM} -i ${DLLIST} --connect-timeout=600 --timeout=600 -m0'
+_DOWNLOADER='aria2c -c -j ${_MAXNUM} -x ${_MAXNUM} -i ${DLLIST} --connect-timeout=600 --timeout=600 -m0'
 
 # Load config file.
 CONFFILE="/etc/apt-fast.conf"


### PR DESCRIPTION
manpage:

> -x, --max-connection-per-server=<NUM>
>              The maximum number of connections to one server for each download.  Default: 1

increase the number can briefly help speed up the progress.
