### PR TITLE
uris: extract, export and report count and size

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -231,11 +231,13 @@ get_uris(){
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
   #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
   #      package URIs.
-  apturis=$(apt-get -y --print-uris "$@")
+  apturis=$(apt-get -qq --print-uris "$@")
   DLLISTCOUNT=$( echo "$apturis" | grep -c "^'" )
-  DLLISTBYTES=$( echo "$apturis" | grep ^Need \
-    | cut -d' ' -f4-5 \
-    | tr -d '[:space:][B]' \
+  DLLISTBYTES=$( echo "$apturis" \
+    | while read line; do
+        echo $line | cut -d' ' -f3
+      done \
+    | awk '{total = total + $1}END{print total}' \
     | numfmt --from=si )
   for urimd5 in $( echo "$apturis" | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
       sed "s/^'\(.\+\)'.*MD5Sum:\(\S\+\)\s*$/\1::MD5Sum:\2/"); do

--- a/apt-fast
+++ b/apt-fast
@@ -116,6 +116,10 @@ eval $(apt-config shell LISTDIR Dir::State::lists/d)
 DLLIST="/tmp/apt-fast.list"
 _MAXNUM=5
 
+# Make available to progress indicators.
+export DLLISTCOUNT=0
+export DLLISTBYTES=0
+
 # Prefix in front of apt-fast output:
 aptfast_prefix=
 
@@ -227,7 +231,13 @@ get_uris(){
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
   #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
   #      package URIs.
-  for urimd5 in $(apt-get -y --print-uris "$@" | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
+  apturis=$(apt-get -y --print-uris "$@")
+  DLLISTCOUNT=$( echo "$apturis" | grep -c "^'" )
+  DLLISTBYTES=$( echo "$apturis" | grep ^Need \
+    | cut -d' ' -f4-5 \
+    | tr -d '[:space:][B]' \
+    | numfmt --from=si )
+  for urimd5 in $( echo "$apturis" | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
       sed "s/^'\(.\+\)'.*MD5Sum:\(\S\+\)\s*$/\1::MD5Sum:\2/"); do
   #for urimd5 in $(cat foo | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
   #    sed "s/^'\(.\+\)'.*MD5Sum:\(\S\+\)\s*$/\1::MD5Sum:\2/"); do
@@ -287,7 +297,7 @@ if [ "$option" == "install" ]; then
   # Then download all files from the list.
   if [ $(cat "$DLLIST" | wc -l) -gt 0 ] && [ ! "$DOWNLOADBEFORE" ]; then
     cat "$DLLIST"
-
+    echo " Need to get $(numfmt --to iec-i --suffix="B" $DLLISTBYTES) of archives from $DLLISTCOUNT packages."
     echo -ne "${cRed} If you want to download the packages on your system press Y else n to abort. [Y/n]:  ${endColor}"
 
     while ((!updsys)); do
@@ -301,6 +311,7 @@ if [ "$option" == "install" ]; then
     done
   else
     result=1
+    echo " Downloading $(numfmt --to iec-i --suffix="B" $DLLISTBYTES) of archives from $DLLISTCOUNT packages."
   fi
 
   echo


### PR DESCRIPTION
- use the apt-get --print-uris output to obtain information and
  present to user prior to downloading.
- make DLLISTCOUNT and DLLISTBYTES available to the aria2 environment
  such that --on-download-[stop|complete] scripts have access.

Signed-off-by: Thell Fowler <thell@tbfowler.name>

`--->8---`

In response to #84 as well as my own desire to have more useful output during docker builds (aka a [progress monitor for noninteractive shells](https://gist.github.com/Thell/7350ee9319a2967e9a0d)).
