### PR TITLE
rewrite get_uris() to overcome SHA256 issue

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -227,17 +227,26 @@ get_uris(){
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
   #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
   #      package URIs.
-  for urimd5 in $(apt-get -y --print-uris "$@" | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
-      sed "s/^'\(.\+\)'.*MD5Sum:\(\S\+\)\s*$/\1::MD5Sum:\2/"); do
-  #for urimd5 in $(cat foo | egrep "^'(http(s|)|(s|)ftp)://[^']+'.+ MD5Sum:\S+\s*$" |
-  #    sed "s/^'\(.\+\)'.*MD5Sum:\(\S\+\)\s*$/\1::MD5Sum:\2/"); do
-    uri="${urimd5%::MD5Sum:*}"
-    checksum="${urimd5#*::MD5Sum:}"
+  apt-get -y --print-uris "$@" | while read pkg_uri_info
+  do
+    uri=$(echo "$pkg_uri_info" | cut -d' ' -f1 | tr -d "'")
+    checksum=$(echo "$pkg_uri_info" | cut -d' ' -f4 | cut -d':' -f2)
+    filename=$(basename $uri) #$(echo "$pkg_uri_info" | cut -d' ' -f2)
+
+    # Aria only supports md5 and sha1. If --print-uris return other than MD5 replace it manually
+    if echo "$pkg_uri_info" | grep -q -v 'MD5Sum'
+    then
+      pkg_name=$(basename $(dirname $uri))
+      patch_md5=$(apt-cache show $pkg_name | grep MD5sum | head -n 1)
+      checksum=$(echo $patch_md5 | cut -d' ' -f2)
+    fi
+
     echo "$(get_mirrors "$uri")" >> "$DLLIST"
     #echo " dir=$DLDIR" >> "$DLLIST"
     echo " checksum=md5=$checksum" >> "$DLLIST"
-    echo " out=$(basename $uri)" >> "$DLLIST"
+    echo " out=$filename" >> "$DLLIST"
   done
+
   #cat "$DLLIST"
   #LCK_RM
   #exit


### PR DESCRIPTION
**rewrite get_uris() to overcome SHA256 issue**
apt-get --print-uris seems to report strongest checksum
this breaks backward compatibility (expecting MD5sum)
known issue:
  * #576420 https://lists.debian.org/deity/2010/04/msg00051.html
  * #799950 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=799950

# Info
This PR rewrite get_uris() function to simplify for expression and patch non-md5 results.
PS: task complete but not accomplished. Getting md5 from last version by now.

# Reproduce it:
```
$ apt-get --print-uris download gnome-orca
'http://es.archive.ubuntu.com/ubuntu/pool/main/g/gnome-orca/gnome-orca_3.10.3-0ubuntu1_all.deb' gnome-orca_3.10.3-0ubuntu1_all.deb 751948 SHA256:88274fd630f476598ddaa3cb86b7a0a741aa9a521512bd4ba79291dc79a2d944
$ apt-fast download gnome-orca
$ cat /tmp/apt-fast.list
# EMPTY!
```