### PR TITLE
xxxdebthttp:// error \t don't translate into Tab

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -234,7 +234,7 @@ get_mirrors(){
         filepath=${1#${mirror}}
         # Build list for aria download list.
         list="${mirrors[@]}"
-        echo -e "${list// /${filepath}\t}$filepath\n"
+        echo -e "${list// /${filepath}\\t}$filepath\n"
         return 0
       fi
     done


### PR DESCRIPTION
line 237
echo -e "${list// /${filepath}\t}$filepath\n"
changed to 
echo -e "${list// /${filepath}\\t}$filepath\n"

with "\" added before "\t" in order to prevent cannot fetch error while using aria2 to download from multiple sources, showing that "xxxx.debthttp://xxx.debthttp://xxxx.debthttp", which indicates "\t" don't translate into "Tab" function.