### PR TITLE
Changed the default DLDIR for the download manager

### DIFF
--- a/apt-fast.conf
+++ b/apt-fast.conf
@@ -104,11 +104,11 @@
 
 
 # Download temp folder for Downloadmanager
-# example /tmp/apt-fast. Standard is /var/cache/archives/apt-fast
+# example /tmp/apt-fast. Standard is /var/cache/apt-fast
 #
-# Default: /var/cache/apt/archives/apt-fast
+# Default: /var/cache/apt/apt-fast
 #
-#DLDIR=/var/cache/apt/archives/apt-fast
+#DLDIR=/var/cache/apt/apt-fast
 
 
 # APT archives cache directory


### PR DESCRIPTION
This is a change to fix issue #100.

`sudo apt-get clean`
or
`sudo apt-fast clean`

Attempt to clean the `/var/cache/apt/archives` folder and seem to find an unexpected folder `apt-fast` there and throw a notice. Moving the `apt-fast` temporary download manager folder fixes this.