### PR TITLE
apt improvements

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -250,7 +250,11 @@ get_uris(){
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
   #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
   #      package URIs.
-  apt-get -y --print-uris "$@" | egrep "^'(http(s|)|(s|)ftp)://" | \
+  case "$_APTMGR" in
+    apt|apt-get) uri_mgr=$_APTMGR;;
+    *) uri_mgr=apt-get;;
+  esac
+  "$uri_mgr" -y --print-uris "$@" | egrep "^'(http(s|)|(s|)ftp)://" | \
   while read pkg_uri_info
   do
     ## --print-uris format is:

--- a/apt-fast
+++ b/apt-fast
@@ -35,6 +35,7 @@ root=1  # default value: we need root privileges
 option=
 for arguments in $@; do
   if [ "$arguments" == "upgrade" ] ||
+      [ "$arguments" == "full-upgrade" ] ||
       [ "$arguments" == "install" ] ||
       [ "$arguments" == "dist-upgrade" ] ||
       [ "$arguments" == "build-dep" ]; then

--- a/apt-fast.conf
+++ b/apt-fast.conf
@@ -3,9 +3,9 @@
 ###################################################################
 # Every item has a default value besides MIRRORS (which is unset).
 
-# Use aptitude or apt-get?
-# Note that for outputting the package URI list, we always use apt-get
-# ...since aptitude can't do this
+# Use aptitude, apt-get, or apt?
+# Note that apt-get is used as a fallback for outputting the
+# package URI list for e.g. aptitude, which can't do this
 # Optionally add the FULLPATH to apt-get or apt-rpm or aptitude
 # e.g. /usr/bin/aptitude
 #


### PR DESCRIPTION
Attempt to ~~resolve #108~~ resolve #105 by:  
- recognizing `apt`'s "full-upgrade" option  
- allowing apt for getting URIs (i.e. use `apt-get` as a fallback for `aptitude`, etc.)

The main outdated portion is the shell completions, which were originally copied from `apt-get` (not sure how to check `_APTMGR` in `apt-fast.conf` and use completions from the user's system). 

Any additional documentation updates needed?