### PR TITLE
Delete failed downloads

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -577,6 +577,10 @@ if [ "$option" == "install" ]; then
 
         eval "${_DOWNLOADER}"  # execute downloadhelper command
         if [ "$(find "$DLDIR" -printf . | wc -c)" -gt 1 ]; then
+          # Delete failed downloads
+          for f in *.aria2; do
+            [ -ne "*.aria2" ] && rm "${f%.*}" "$f"
+          done
           # Move all packages to the apt install directory by force to ensure
           # already existing debs which may be incomplete are replaced
           find . -type f \( -name '*.deb' -o -name '*.ddeb' \) -execdir mv -ft "$APTCACHE" {} \+

--- a/apt-fast
+++ b/apt-fast
@@ -579,7 +579,7 @@ if [ "$option" == "install" ]; then
         if [ "$(find "$DLDIR" -printf . | wc -c)" -gt 1 ]; then
           # Delete failed downloads
           for f in *.aria2; do
-            [ -ne "*.aria2" ] && rm "${f%.*}" "$f"
+            [[ "$f" -ne "*.aria2" ]] && rm "${f%.*}" "$f"
           done
           # Move all packages to the apt install directory by force to ensure
           # already existing debs which may be incomplete are replaced


### PR DESCRIPTION
Fix for unreliable internet connection like mine.
Basically, if aria failed to download, like checksum mismatch for example, it still copy .deb file to apt archives, so when I continue the install, I get broken install because it is not valid .deb package.
Aria2 create a filename.extension.aria2 when something goes wrong, like above. This addition make sure corrupted file is deleted before move to apt archives, so it can re-download the corrupted package.