### PR TITLE
Fixed wrong string comparison

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -579,7 +579,7 @@ if [ "$option" == "install" ]; then
         if [ "$(find "$DLDIR" -printf . | wc -c)" -gt 1 ]; then
           # Delete failed downloads
           for f in *.aria2; do
-            [[ "$f" -ne "*.aria2" ]] && rm "${f%.*}" "$f"
+            [[ "$f" != "*.aria2" ]] && rm "${f%.*}" "$f"
           done
           # Move all packages to the apt install directory by force to ensure
           # already existing debs which may be incomplete are replaced


### PR DESCRIPTION
![Screenshot](https://user-images.githubusercontent.com/25661768/103124026-ea136b00-46b8-11eb-8053-1e67de3359e2.png)


I'm sorry, in previous PR, I use wrong comparison operator that led to conversion error if filename contain unexpected character followed by number like the picture above.
This PR should've fixed that.