### PR TITLE
Reimplement #184 while fixing #185

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -577,10 +577,21 @@ if [ "$option" == "install" ]; then
 
         eval "${_DOWNLOADER}"  # execute downloadhelper command
         if [ "$(find "$DLDIR" -printf . | wc -c)" -gt 1 ]; then
-          # Delete failed downloads
-          for f in *.aria2; do
-            [[ "$f" -ne "*.aria2" ]] && rm "${f%.*}" "$f"
-          done
+          # When Aria2c downloads a file and detects it is corrupted, its filename won't be renamed back to its actual name,
+          # preserving .aria2 file extension, which also indicates when a file hasn't been completely downloaded.
+          
+          # Delete incomplete/corrupted downloaded files, if any: Not recursive, as we don't expect any dirs to exist within $DLDIR
+          if [ "$(find "$DLDIR" -maxdepth '1' -type 'f' -name '*.aria2' -printf '.' | wc -c)" -gt 0 ]; then
+            for x in *.aria2; do
+              rm -fv "$x" "${x%.aria2}.deb" > /dev/null 2>&1
+            done
+            # Could have used find instead, but it'd have taken extra steps going that way:
+            # Specially when ypu don't want to touch $IFS at all...
+            #  while read -r file; do
+            #    rm $(printf '%s %s' "$file" "$(printf '%s' "$file" | sed -E 's/\.aria2$/.deb/g')")
+            #  done <<< $(find '.''' -maxdepth '1' -type 'f' -name '*.aria2' | sort -u)
+          fi
+          
           # Move all packages to the apt install directory by force to ensure
           # already existing debs which may be incomplete are replaced
           find . -type f \( -name '*.deb' -o -name '*.ddeb' \) -execdir mv -ft "$APTCACHE" {} \+

--- a/apt-fast
+++ b/apt-fast
@@ -583,7 +583,7 @@ if [ "$option" == "install" ]; then
           # Delete incomplete/corrupted downloaded files, if any: Not recursive, as we don't expect any dirs to exist within $DLDIR
           if [ "$(find "$DLDIR" -maxdepth '1' -type 'f' -name '*.aria2' -printf '.' | wc -c)" -gt 0 ]; then
             for x in *.aria2; do
-              rm -fv "$x" "${x%.aria2}.deb" > /dev/null 2>&1
+              rm -fv "$x" "${x%.aria2}" > /dev/null 2>&1
             done
             # Could have used find instead, but it'd have taken extra steps going that way:
             # Specially when ypu don't want to touch $IFS at all...

--- a/apt-fast
+++ b/apt-fast
@@ -577,21 +577,15 @@ if [ "$option" == "install" ]; then
 
         eval "${_DOWNLOADER}"  # execute downloadhelper command
         if [ "$(find "$DLDIR" -printf . | wc -c)" -gt 1 ]; then
+
+          # Delete incomplete/corrupted downloaded files, if any: Not recursive, as we don't expect any dirs to exist within $DLDIR.
+
           # When Aria2c downloads a file and detects it is corrupted, its filename won't be renamed back to its actual name,
           # preserving .aria2 file extension, which also indicates when a file hasn't been completely downloaded.
-          
-          # Delete incomplete/corrupted downloaded files, if any: Not recursive, as we don't expect any dirs to exist within $DLDIR
-          if [ "$(find "$DLDIR" -maxdepth '1' -type 'f' -name '*.aria2' -printf '.' | wc -c)" -gt 0 ]; then
-            for x in *.aria2; do
-              rm -fv "$x" "${x%.aria2}" > /dev/null 2>&1
-            done
-            # Could have used find instead, but it'd have taken extra steps going that way:
-            # Specially when ypu don't want to touch $IFS at all...
-            #  while read -r file; do
-            #    rm $(printf '%s %s' "$file" "$(printf '%s' "$file" | sed -E 's/\.aria2$/.deb/g')")
-            #  done <<< $(find '.''' -maxdepth '1' -type 'f' -name '*.aria2' | sort -u)
-          fi
-          
+          for x in *.aria2; do
+            rm -f "$x" "${x%.aria2}"
+          done
+
           # Move all packages to the apt install directory by force to ensure
           # already existing debs which may be incomplete are replaced
           find . -type f \( -name '*.deb' -o -name '*.ddeb' \) -execdir mv -ft "$APTCACHE" {} \+


### PR DESCRIPTION
<h1>Why?</h1>

I originally posted this PR at [dityaaa/apt-fast #1](https://github.com/dityaaa/apt-fast/pull/1), in an attempt to let @dityaaa know what changes I'd do to #184, while letting her take all the credit for her idea (That's why I initially didn't post these changes directly at [ilikenwf/apt-fast](https://github.com/ilikenwf/apt-fast)): Unfortunately, It seems my recommendations weren't seen on time, and as a result we couldn't prevent #185.

This time, I decided to post this PR directly at [ilikenwf/apt-fast](https://github.com/ilikenwf/apt-fast) rather than [dityaaa/apt-fast](https://github.com/dityaaa/apt-fast) to let @dityaaa delete her `apt-fast` fork, in case it has become useless, now that #184 has been merged.

Finally, I also added some description & documentation.

<h1>Tests</h1>

Probably due to how few changes were made by #184, we ended up overlooking testing, contributing to the appearance of #185, so this time I've already tested my changes by using `apt-fast` to install `openjdk-8-*` with no problems at all.

I couldn't think of a better testcase, so any feedback on this is always appreciated.

<details><summary><i>Screenshot</i></summary>

![imagen](https://user-images.githubusercontent.com/8020999/103144239-8d7d7380-46eb-11eb-9a56-7b0e471562f9.png)
</details>

<h1>Known Issues</h1>

As discussed in #184, and given the fact this is just a reimplemenation of @dityaaa's idea, this approach won't handle incomplete non-corrupted files in a special way: As a result, all incomplete files (No matter if they're corrupted or not) & actually corrupted files will be deleted as well.

Probably, at a later point, that will be addressed: **_Should a new issue be opened to keep that in mind?_**

<h2>More Info</h2>
#184
<br> 
#185
<br> 
<a href=https://github.com/dityaaa/apt-fast/pull/1>dityaaa/apt-fast #1</a>