### PR TITLE
[Untested] Fix incorrect behavior when `$_APTMGR` it's a full path to a binary

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -37,7 +37,7 @@ msg(){
 # check its existence, just in case
 real_APT="/usr/bin/apt-get"
 
-if [ '!' -x "$real_APT"]; then
+if [ '!' -x "$real_APT" ]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
     exit 1

--- a/apt-fast
+++ b/apt-fast
@@ -37,7 +37,7 @@ msg(){
 # check its existence, just in case
 real_APT="/usr/bin/apt-get"
 
-if ['!' -x "$real_APT"]; then
+if [ '!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
     exit 1

--- a/apt-fast
+++ b/apt-fast
@@ -39,7 +39,7 @@ real_APT="/usr/bin/apt-get"
 
 if ['!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
-    msg 'warning' "$_err" "$_err"
+    msg 'warning' "$_err"
     echo
     read -p 'Press ENTER to exit'
     exit 64
@@ -475,7 +475,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$(basename $_APTMGR)" == "apt" ]; then
+if [ "$(basename "$_APTMGR")" == "apt" ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# apt-fast v1.9.1
+# apt-fast v1.9.11
 # Use this just like aptitude or apt-get for faster package downloading.
 #
 # Copyright: 2008-2012 Matt Parnell, http://www.mattparnell.com

--- a/apt-fast
+++ b/apt-fast
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# apt-fast v1.9
+# apt-fast v1.9.1
 # Use this just like aptitude or apt-get for faster package downloading.
 #
 # Copyright: 2008-2012 Matt Parnell, http://www.mattparnell.com
@@ -32,6 +32,18 @@ msg(){
     echo -e "${msg_options[@]}" "${aptfast_prefix}${beginColor}$1${endColor}" >&2
   fi
 }
+
+# Store fullpath of real "apt-get" and
+# check its existence, just in case
+real_APT="/usr/bin/apt-get"
+
+if ['!' -x "$real_APT"]; then
+    _err="We need $real_APT to work, but it doesn't exist..."
+    msg 'warning' "$_err" "$_err"
+    echo
+    read -p 'Press ENTER to exit'
+    exit 64
+fi
 
 # Search for known options and decide if root privileges are needed.
 root=1  # default value: we need root privileges
@@ -321,12 +333,12 @@ get_uris(){
 
   # Add header to overwrite file.
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
-  #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
-  #      package URIs.
-  case "$_APTMGR" in
-    apt|apt-get) uri_mgr=$_APTMGR;;
-    *) uri_mgr=apt-get;;
-  esac
+  
+  # NOTE: Since "aptitude" lacks this functionality, "apt" has an
+  # unstable CLI, and "$_APTMGR" could be pointing anywhere
+  # we just use "$real_APT" to get package URI's and avoid problems
+  uri_mgr="$real_APT"
+  
   uris_full="$("$uri_mgr" "${APT_SCRIPT_WARNING[@]}" -y --print-uris "$@")"
   CLEANUP_STATE="$?"
   if [ "$CLEANUP_STATE" -ne 0 ]
@@ -463,7 +475,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$_APTMGR" == "apt" ]; then
+if [ "$(basename $_APTMGR)" == "apt" ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 
@@ -601,7 +613,7 @@ if [ "$option" == "install" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ -z "$DOWNLOAD_ONLY" ] || [ "$_APTMGR" == "aptitude" ]; then
+  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "$_APTMGR")" == "aptitude" ]; then
     "${_APTMGR}" "${APT_SCRIPT_WARNING[@]}" "$@"
   fi
 
@@ -630,7 +642,7 @@ elif [ "$option" == "download" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ "$_APTMGR" == "aptitude" ]; then
+  if [ "$(basename "$_APTMGR")" == "aptitude" ]; then
     "${_APTMGR}" "$@"
   fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -40,9 +40,7 @@ real_APT="/usr/bin/apt-get"
 if ['!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
-    echo
-    read -p 'Press ENTER to exit'
-    exit 64
+    exit 1
 fi
 
 # Search for known options and decide if root privileges are needed.

--- a/apt-fast
+++ b/apt-fast
@@ -33,15 +33,8 @@ msg(){
   fi
 }
 
-# Store fullpath of real "apt-get" and
-# check its existence, just in case
+# Stores fullpath of real "apt-get"
 real_APT="/usr/bin/apt-get"
-
-if [ '!' -x "$real_APT" ]; then
-    _err="We need $real_APT to work, but it doesn't exist..."
-    msg 'warning' "$_err"
-    exit 1
-fi
 
 # Search for known options and decide if root privileges are needed.
 root=1  # default value: we need root privileges
@@ -129,7 +122,7 @@ LCK_FD=99
 
 # Set default package manager, APT cache, temporary download dir,
 # temporary download list file, and maximal parallel downloads
-_APTMGR="$real_APT"
+_APTMGR="${real_APT}"
 eval "$(apt-config shell APTCACHE Dir::Cache::archives/d)"
 # Check if APT config option Dir::Cache::archives::apt-fast-partial is set.
 eval "$(apt-config shell apt_fast_partial Dir::Cache::archives::apt-fast-partial/d)"
@@ -178,6 +171,12 @@ for Prefix in /usr/local/etc /etc; do
         break
     fi
 done
+
+# Check if "${real_APT}" exists
+if [ '!' -x "${real_APT}" ]; then
+    msg "We use ${real_APT} in case ${_APTMGR} doesn't work, but it doesn't exist!" 'warning'
+    exit 1
+fi
 
 # no proxy as default
 ftp_proxy=
@@ -331,12 +330,13 @@ get_uris(){
 
   # Add header to overwrite file.
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
-  
-  # NOTE: Since "aptitude" lacks this functionality, "apt" has an
-  # unstable CLI, and "$_APTMGR" could be pointing anywhere
-  # we just use "$real_APT" to get package URI's and avoid problems
-  uri_mgr="$real_APT"
-  
+  # NOTE: "aptitude" doesn't have this functionality
+  # so we use either "${_APTMGR}" or "${real_APT}"
+  # to get package URI's
+  case "$(basename "${_APTMGR}")" in
+    'apt'|'apt-get') uri_mgr="${_APTMGR}";;
+    *) uri_mgr="${real_APT}";;
+  esac
   uris_full="$("$uri_mgr" "${APT_SCRIPT_WARNING[@]}" -y --print-uris "$@")"
   CLEANUP_STATE="$?"
   if [ "$CLEANUP_STATE" -ne 0 ]
@@ -473,7 +473,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$(basename "$_APTMGR")" == "apt" ]; then
+if [ "$(basename "${_APTMGR}")" == 'apt' ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 
@@ -611,7 +611,7 @@ if [ "$option" == "install" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "$_APTMGR")" == "aptitude" ]; then
+  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "${_APTMGR}")" == 'aptitude' ]; then
     "${_APTMGR}" "${APT_SCRIPT_WARNING[@]}" "$@"
   fi
 
@@ -640,7 +640,7 @@ elif [ "$option" == "download" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ "$(basename "$_APTMGR")" == "aptitude" ]; then
+  if [ "$(basename "${_APTMGR}")" == 'aptitude' ]; then
     "${_APTMGR}" "$@"
   fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -131,7 +131,7 @@ LCK_FD=99
 
 # Set default package manager, APT cache, temporary download dir,
 # temporary download list file, and maximal parallel downloads
-_APTMGR=apt-get
+_APTMGR="$real_APT"
 eval "$(apt-config shell APTCACHE Dir::Cache::archives/d)"
 # Check if APT config option Dir::Cache::archives::apt-fast-partial is set.
 eval "$(apt-config shell apt_fast_partial Dir::Cache::archives::apt-fast-partial/d)"

--- a/apt-fast
+++ b/apt-fast
@@ -33,9 +33,6 @@ msg(){
   fi
 }
 
-# Stores fullpath of real "apt-get"
-real_APT="/usr/bin/apt-get"
-
 # Search for known options and decide if root privileges are needed.
 root=1  # default value: we need root privileges
 option=
@@ -111,7 +108,6 @@ if [ "$root" = 1 ] && [ "$UID" != 0 ]; then
             "$0" "$@"
 fi
 
-
 # Define lockfile.
 # Use /tmp as directory because everybody (not only root) has to have write
 # permissions.
@@ -122,7 +118,7 @@ LCK_FD=99
 
 # Set default package manager, APT cache, temporary download dir,
 # temporary download list file, and maximal parallel downloads
-_APTMGR="${real_APT}"
+_APTMGR='apt-get'
 eval "$(apt-config shell APTCACHE Dir::Cache::archives/d)"
 # Check if APT config option Dir::Cache::archives::apt-fast-partial is set.
 eval "$(apt-config shell apt_fast_partial Dir::Cache::archives::apt-fast-partial/d)"
@@ -171,12 +167,6 @@ for Prefix in /usr/local/etc /etc; do
         break
     fi
 done
-
-# Check if "${real_APT}" exists
-if [ '!' -x "${real_APT}" ]; then
-    msg "We use ${real_APT} in case ${_APTMGR} doesn't work, but it doesn't exist!" 'warning'
-    exit 1
-fi
 
 # no proxy as default
 ftp_proxy=
@@ -331,11 +321,10 @@ get_uris(){
   # Add header to overwrite file.
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
   # NOTE: "aptitude" doesn't have this functionality
-  # so we use either "${_APTMGR}" or "${real_APT}"
-  # to get package URI's
+  # so we use "${_APTMGR}" to get package URI's
   case "$(basename "${_APTMGR}")" in
     'apt'|'apt-get') uri_mgr="${_APTMGR}";;
-    *) uri_mgr="${real_APT}";;
+    *) uri_mgr='apt-get';;
   esac
   uris_full="$("$uri_mgr" "${APT_SCRIPT_WARNING[@]}" -y --print-uris "$@")"
   CLEANUP_STATE="$?"


### PR DESCRIPTION
<h1> Why? </h1>

Just as @DogSledder pointed out in #188, `apt-fast.conf` [states](https://github.com/ilikenwf/apt-fast/blob/5f853c97ddc3704898b47e2e5af9714d68e2ff69/apt-fast.conf#L9) that `$_APTMGR` _may_ contain a full path to a binary rather than just a name, but in practice, doing so would end up confusing `apt-fast` when trying to detect which package manager was selected, obviously causing an error.

This PR makes use of `basename` command, from [GNU Coreutils](https://www.gnu.org/software/coreutils/basename) to fix #188, which can be found preinstalled on most GNU/Linux distros, including Debian of course.

It's worth noting that these changes **_haven't been tested already_** at the time being: Instead of conducting a series of different tests, I'll start using this modified `apt-fast` in a regular basis in the next days to see if something's wrong.

---------------

I'll keep this PR updated.
