### PR TITLE
[Feature Request] Reliable way to invoke `apt-get`

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -37,7 +37,7 @@ msg(){
 # check its existence, just in case
 real_APT="/usr/bin/apt-get"
 
-if [ '!' -x "$real_APT"]; then
+if [ '!' -x "$real_APT" ]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
     exit 1

--- a/apt-fast
+++ b/apt-fast
@@ -37,7 +37,7 @@ msg(){
 # check its existence, just in case
 real_APT="/usr/bin/apt-get"
 
-if ['!' -x "$real_APT"]; then
+if [ '!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
     exit 1

--- a/apt-fast
+++ b/apt-fast
@@ -39,7 +39,7 @@ real_APT="/usr/bin/apt-get"
 
 if ['!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
-    msg 'warning' "$_err" "$_err"
+    msg 'warning' "$_err"
     echo
     read -p 'Press ENTER to exit'
     exit 64
@@ -475,7 +475,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$(basename $_APTMGR)" == "apt" ]; then
+if [ "$(basename "$_APTMGR")" == "apt" ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# apt-fast v1.9.1
+# apt-fast v1.9.11
 # Use this just like aptitude or apt-get for faster package downloading.
 #
 # Copyright: 2008-2012 Matt Parnell, http://www.mattparnell.com

--- a/apt-fast
+++ b/apt-fast
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# apt-fast v1.9
+# apt-fast v1.9.1
 # Use this just like aptitude or apt-get for faster package downloading.
 #
 # Copyright: 2008-2012 Matt Parnell, http://www.mattparnell.com
@@ -32,6 +32,18 @@ msg(){
     echo -e "${msg_options[@]}" "${aptfast_prefix}${beginColor}$1${endColor}" >&2
   fi
 }
+
+# Store fullpath of real "apt-get" and
+# check its existence, just in case
+real_APT="/usr/bin/apt-get"
+
+if ['!' -x "$real_APT"]; then
+    _err="We need $real_APT to work, but it doesn't exist..."
+    msg 'warning' "$_err" "$_err"
+    echo
+    read -p 'Press ENTER to exit'
+    exit 64
+fi
 
 # Search for known options and decide if root privileges are needed.
 root=1  # default value: we need root privileges
@@ -321,12 +333,12 @@ get_uris(){
 
   # Add header to overwrite file.
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
-  #NOTE: aptitude doesn't have this functionality, so we use apt-get to get
-  #      package URIs.
-  case "$_APTMGR" in
-    apt|apt-get) uri_mgr=$_APTMGR;;
-    *) uri_mgr=apt-get;;
-  esac
+  
+  # NOTE: Since "aptitude" lacks this functionality, "apt" has an
+  # unstable CLI, and "$_APTMGR" could be pointing anywhere
+  # we just use "$real_APT" to get package URI's and avoid problems
+  uri_mgr="$real_APT"
+  
   uris_full="$("$uri_mgr" "${APT_SCRIPT_WARNING[@]}" -y --print-uris "$@")"
   CLEANUP_STATE="$?"
   if [ "$CLEANUP_STATE" -ne 0 ]
@@ -463,7 +475,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$_APTMGR" == "apt" ]; then
+if [ "$(basename $_APTMGR)" == "apt" ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 
@@ -601,7 +613,7 @@ if [ "$option" == "install" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ -z "$DOWNLOAD_ONLY" ] || [ "$_APTMGR" == "aptitude" ]; then
+  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "$_APTMGR")" == "aptitude" ]; then
     "${_APTMGR}" "${APT_SCRIPT_WARNING[@]}" "$@"
   fi
 
@@ -630,7 +642,7 @@ elif [ "$option" == "download" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ "$_APTMGR" == "aptitude" ]; then
+  if [ "$(basename "$_APTMGR")" == "aptitude" ]; then
     "${_APTMGR}" "$@"
   fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -40,9 +40,7 @@ real_APT="/usr/bin/apt-get"
 if ['!' -x "$real_APT"]; then
     _err="We need $real_APT to work, but it doesn't exist..."
     msg 'warning' "$_err"
-    echo
-    read -p 'Press ENTER to exit'
-    exit 64
+    exit 1
 fi
 
 # Search for known options and decide if root privileges are needed.

--- a/apt-fast
+++ b/apt-fast
@@ -33,15 +33,8 @@ msg(){
   fi
 }
 
-# Store fullpath of real "apt-get" and
-# check its existence, just in case
+# Stores fullpath of real "apt-get"
 real_APT="/usr/bin/apt-get"
-
-if [ '!' -x "$real_APT" ]; then
-    _err="We need $real_APT to work, but it doesn't exist..."
-    msg 'warning' "$_err"
-    exit 1
-fi
 
 # Search for known options and decide if root privileges are needed.
 root=1  # default value: we need root privileges
@@ -129,7 +122,7 @@ LCK_FD=99
 
 # Set default package manager, APT cache, temporary download dir,
 # temporary download list file, and maximal parallel downloads
-_APTMGR="$real_APT"
+_APTMGR="${real_APT}"
 eval "$(apt-config shell APTCACHE Dir::Cache::archives/d)"
 # Check if APT config option Dir::Cache::archives::apt-fast-partial is set.
 eval "$(apt-config shell apt_fast_partial Dir::Cache::archives::apt-fast-partial/d)"
@@ -178,6 +171,12 @@ for Prefix in /usr/local/etc /etc; do
         break
     fi
 done
+
+# Check if "${real_APT}" exists
+if [ '!' -x "${real_APT}" ]; then
+    msg "We use ${real_APT} in case ${_APTMGR} doesn't work, but it doesn't exist!" 'warning'
+    exit 1
+fi
 
 # no proxy as default
 ftp_proxy=
@@ -331,12 +330,13 @@ get_uris(){
 
   # Add header to overwrite file.
   echo "# apt-fast mirror list: $(date)" > "$DLLIST"
-  
-  # NOTE: Since "aptitude" lacks this functionality, "apt" has an
-  # unstable CLI, and "$_APTMGR" could be pointing anywhere
-  # we just use "$real_APT" to get package URI's and avoid problems
-  uri_mgr="$real_APT"
-  
+  # NOTE: "aptitude" doesn't have this functionality
+  # so we use either "${_APTMGR}" or "${real_APT}"
+  # to get package URI's
+  case "$(basename "${_APTMGR}")" in
+    'apt'|'apt-get') uri_mgr="${_APTMGR}";;
+    *) uri_mgr="${real_APT}";;
+  esac
   uris_full="$("$uri_mgr" "${APT_SCRIPT_WARNING[@]}" -y --print-uris "$@")"
   CLEANUP_STATE="$?"
   if [ "$CLEANUP_STATE" -ne 0 ]
@@ -473,7 +473,7 @@ fi
 
 # Disable script warning if apt is used.
 APT_SCRIPT_WARNING=()
-if [ "$(basename "$_APTMGR")" == "apt" ]; then
+if [ "$(basename "${_APTMGR}")" == 'apt' ]; then
     APT_SCRIPT_WARNING=(-o "Apt::Cmd::Disable-Script-Warning=true")
 fi
 
@@ -611,7 +611,7 @@ if [ "$option" == "install" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "$_APTMGR")" == "aptitude" ]; then
+  if [ -z "$DOWNLOAD_ONLY" ] || [ "$(basename "${_APTMGR}")" == 'aptitude' ]; then
     "${_APTMGR}" "${APT_SCRIPT_WARNING[@]}" "$@"
   fi
 
@@ -640,7 +640,7 @@ elif [ "$option" == "download" ]; then
   fi
 
   # different problem resolving for aptitude
-  if [ "$(basename "$_APTMGR")" == "aptitude" ]; then
+  if [ "$(basename "${_APTMGR}")" == 'aptitude' ]; then
     "${_APTMGR}" "$@"
   fi
 

--- a/apt-fast
+++ b/apt-fast
@@ -131,7 +131,7 @@ LCK_FD=99
 
 # Set default package manager, APT cache, temporary download dir,
 # temporary download list file, and maximal parallel downloads
-_APTMGR=apt-get
+_APTMGR="$real_APT"
 eval "$(apt-config shell APTCACHE Dir::Cache::archives/d)"
 # Check if APT config option Dir::Cache::archives::apt-fast-partial is set.
 eval "$(apt-config shell apt_fast_partial Dir::Cache::archives::apt-fast-partial/d)"


### PR DESCRIPTION
# Why?

This PR attempts to cover an edge case which might occur [here](https://github.com/ilikenwf/apt-fast/blob/5f853c97ddc3704898b47e2e5af9714d68e2ff69/apt-fast#L328) if an user attempts to use aptitude (or any other custom package manager) in `apt-fast.conf`, by overriding `"${_APTMGR}"`, while being in an environment which prioritizes `/usr/local/bin` over `/usr/bin` in `"${PATH}"`, with a symlink from e.g. `/usr/local/bin/aptitude` -> `/usr/bin/apt.fast`.

Trying to invoke `apt-fast` with this setup would cause `apt-fast` to call himself.

## Is this necessary?

Although such environment would seem extremely unusual at first, taking a closer look to your `"${PATH}"` might reveal that, in fact, you could be using a similar configuration without even knowing (Like i discovered); also, if we take into account that `apt-fast.conf` actually [allows](https://github.com/ilikenwf/apt-fast/blob/5f853c97ddc3704898b47e2e5af9714d68e2ff69/apt-fast.conf#L9) `"${_APTMGR}"` to be overridden, than means that we'd just need to also create a symlink like the one above described to trigger this edge case.

<h2>So? What's the idea?</h2>

The idea behind this PR it's quite simple: We just need to make sure that we're calling `/usr/bin/apt-get` whenever we call for `apt-get`.

<details><summary>This can be achieved in many ways</summary>
<br>

* We could simply go ahead and replace each `apt-get` occurence within `apt-fast` with `/usr/bin/apt-get`
* Or we could store `/usr/bin/apt-get` into a variable, and replace each `apt-get` occurence with `"${var}"` [Currently in use]
* <details><summary>Or we could use <code>whereis</code> command, from <a href=https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/>utils-linux</a> package to do something like this</summary><br><pre lang=bash>whereis_APT=($(whereis -b 'apt-get')) # apt-get: /usr/bin/apt-get</pre><pre lang=bash>real_APT="${whereis_APT[1]}"</pre><pre lang=bash>echo "${real_APT}" # /usr/bin/apt-get</pre><br></details>

</details>

## Are there any drawbacks?
Strictly talking, there could be a few:

### Option 1
This option would end up adding a lot of hardcoded lines into `apt-fast`
### Option 2
This option requires an additional variable to store `apt-get` fullpath, and just one hardcoded line.
### Option 3
This option requires (at least) an additional variable to store `apt-get` fullpath, and adding another dependency: <a href=https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/>utils-linux</a> package.

After a little research, seems `systemd` package depends on `utils-linux`, so that means `utils-linux` comes preinstalled, at least in [Ubuntu](https://packages.ubuntu.com/xenial/systemd) (Debian's [systemd](https://packages.debian.org/en/sid/systemd) doesn't seem to share that dependency)

## What if we just go and delete those false promises from `apt-fast.conf`?

That's also an option.

## Final notes
As always, If I made some mistake, or if you have any suggestion, it's always welcome.