### PR TITLE
don't rely on dpkg to check for aria2/aria2c

### DIFF
--- a/quick-install.sh
+++ b/quick-install.sh
@@ -2,7 +2,7 @@
 set -e
 
 apt_fast_installation() {
-  if ! dpkg-query --show aria2 >/dev/null 2>&1; then
+  if ! type aria2c >/dev/null 2>&1; then
     sudo apt-get update
     sudo apt-get install -y aria2
   fi


### PR DESCRIPTION
Changes to check for aria2c with the shell's built-in "type" command instead of querying dpkg.