### PR TITLE
README: update PPA signing key (RSA 4096)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To retrieve the signed keys and install apt-fast, execute the following commands
 
 ```bash
 mkdir -p /etc/apt/keyrings
-curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B" | gpg --dearmor -o /etc/apt/keyrings/apt-fast.gpg
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBC5934FD3DEBD4DAEA544F791E2824A7F22B44BD" | gpg --dearmor -o /etc/apt/keyrings/apt-fast.gpg
 apt-get update
 apt-get install apt-fast
 ```


### PR DESCRIPTION
PPA has updated the signing key, see [1]. Now the archive is signed with both the new key and the legacy (RSA 1024) one.

Fixes #238

[1]: https://code.launchpad.net/~apt-fast/+archive/ubuntu/stable